### PR TITLE
Do not hardcode module path in scripts.

### DIFF
--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 
-MODPATH="/data/adb/modules/safetynet-fix"
+MODPATH=${0%/*}
 
 # Get runtime version
 sdk="$(getprop ro.build.version.sdk)"


### PR DESCRIPTION
Some magisk fork's module path is not in '/data/adb/modules' (eg. Magisk Lite)