### PR TITLE
Edit moduleName

### DIFF
--- a/riru/module.gradle
+++ b/riru/module.gradle
@@ -22,7 +22,7 @@ ext {
     */
     magiskModuleId = "safetynet-fix"
 
-    moduleName = "Universal SafetyNet Fix"
+    moduleName = "Riru - Universal SafetyNet Fix"
     moduleAuthor = "kdrag0n"
     moduleDescription = "A universal fix for SafetyNet on Android 7–12 devices with hardware attestation and unlocked bootloaders. Requires MagiskHide and Riru $moduleMinRiruVersionName or newer."
     moduleVersion = "v2.0.0"


### PR DESCRIPTION
More clearly displayed as a RIRU module
Adding "Riru -" in front of the original module name can let users know clearly that they are using Riru modules
If you don’t like this change, please close this PR