### PR TITLE
magisk: fix OnePlus display issues, reorganize props

### DIFF
--- a/riru/template/magisk_module/service.sh
+++ b/riru/template/magisk_module/service.sh
@@ -1,4 +1,5 @@
 #!/system/bin/sh
+# Conditional MagiskHide properties
 
 maybe_set_prop() {
     local prop="$1"
@@ -15,7 +16,7 @@ maybe_set_prop ro.bootmode recovery unknown
 maybe_set_prop ro.boot.mode recovery unknown
 maybe_set_prop vendor.boot.mode recovery unknown
 
-# MIUI region
+# MIUI cross-region flash
 maybe_set_prop ro.boot.hwc CN GLOBAL
 maybe_set_prop ro.boot.hwcountry China GLOBAL
 
@@ -26,3 +27,13 @@ if [[ "$(cat /sys/fs/selinux/enforce)" == "0" ]]; then
     chmod 640 /sys/fs/selinux/enforce
     chmod 440 /sys/fs/selinux/policy
 fi
+
+# Late props which must be set after boot_completed
+{
+    until [[ "$(getprop sys.boot_completed)" == "1" ]]; do
+        sleep 1
+    done
+
+    # avoid breaking OnePlus display modes/fingerprint scanners
+    resetprop vendor.boot.verifiedbootstate green
+}&

--- a/riru/template/magisk_module/system.prop
+++ b/riru/template/magisk_module/system.prop
@@ -1,19 +1,22 @@
+# Basic MagiskHide properties
+
 # RootBeer, Microsoft
 ro.build.tags=release-keys
+
+# Samsung
+ro.boot.warranty_bit=0
+ro.vendor.boot.warranty_bit=0
+ro.vendor.warranty_bit=0
+ro.warranty_bit=0
 
 # SafetyNet
 ro.boot.flash.locked=1
 ro.boot.verifiedbootstate=green
 ro.boot.veritymode=enforcing
 ro.boot.vbmeta.device_state=locked
+vendor.boot.vbmeta.device_state=locked
 
-# Additional properties from MagiskHide
-ro.boot.warranty_bit=0
-ro.warranty_bit=0
+# Other
+ro.build.type=user
 ro.debuggable=0
 ro.secure=1
-ro.build.type=user
-ro.vendor.boot.warranty_bit=0
-ro.vendor.warranty_bit=0
-vendor.boot.vbmeta.device_state=locked
-vendor.boot.verifiedbootstate=green


### PR DESCRIPTION
- vendor.boot.verifiedbootstate was a "late_prop" in MagiskHide so needs to be set at boot_completed; this works around OnePlus display mode and in-display fingerprint reader breakage when this prop is reset to green earlier in the boot
- tidy up prop groupings and document them a bit more

Fixes #92 