### PR TITLE
magisk: Ensure DenyList is enabled

### DIFF
--- a/magisk/post-fs-data.sh
+++ b/magisk/post-fs-data.sh
@@ -1,4 +1,7 @@
 #!/system/bin/sh
 
+# DenyList must be enabled to pass basicIntegrity
+magisk --denylist enable
+
 # Remove Play Services from DenyList, otherwise the Zygisk module won't load
 magisk --denylist rm com.google.android.gms


### PR DESCRIPTION
- DenyList must be enabled to pass basicIntegrity
- also allows seamlessly upgrading to Magisk 23010+ and USNF 2.2.x since Magisk currently only allows Zygisk setting to stay enabled via the Magisk app before the update reboot, with DenyList showing enabled but reverts post-reboot