### PR TITLE
magisk: Fix Realme fingerprint reader issues

### DIFF
--- a/magisk/service.sh
+++ b/magisk/service.sh
@@ -34,6 +34,9 @@ fi
         sleep 1
     done
 
+    # avoid breaking Realme fingerprint scanners
+    resetprop ro.boot.flash.locked 1
+
     # avoid breaking OnePlus display modes/fingerprint scanners
     resetprop vendor.boot.verifiedbootstate green
 }&

--- a/magisk/system.prop
+++ b/magisk/system.prop
@@ -10,7 +10,6 @@ ro.vendor.warranty_bit=0
 ro.warranty_bit=0
 
 # SafetyNet
-ro.boot.flash.locked=1
 ro.boot.verifiedbootstate=green
 ro.boot.veritymode=enforcing
 ro.boot.vbmeta.device_state=locked


### PR DESCRIPTION
- move ro.boot.flash.locked to late props since any earlier appears to break Realme fingerprint readers on RUI 2.0 devices

Thanks @byxiaorun for finding the problem prop, and @Jowat97 for testing

Fixes #115