### PR TITLE
magisk: Add circumvention of OnePlus' oem unlock counter

### DIFF
--- a/magisk/system.prop
+++ b/magisk/system.prop
@@ -9,6 +9,9 @@ ro.vendor.boot.warranty_bit=0
 ro.vendor.warranty_bit=0
 ro.warranty_bit=0
 
+# OnePlus
+ro.is_ever_orange=0
+
 # SafetyNet
 ro.boot.verifiedbootstate=green
 ro.boot.veritymode=enforcing


### PR DESCRIPTION
- I recently discovered `ro.is_ever_orange` on OOS 11, which gets set roughly 32 seconds after boot completed and is equal to the number of times a device has ever been `fastboot oem unlock`ed (verifiedbootstate orange)
- a fresh MSM (i.e. factory locked device) has it set to 0, and using system.prop to set it to 0 earlier in the boot seems to keep it set to 0 instead of the real unlock count
- I haven't seen this exploited anywhere, though I presume it exists for a reason, so probably good to manage it as well