### PR TITLE
Support update.json Magisk update checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+**If you found this helpful, please consider supporting development with a [recurring donation](https://patreon.com/kdrag0n) for rewards such as early access to updates, exclusive behind-the-scenes development news, and priority support. Alternatively, [you can also buy me a coffee](https://paypal.me/kdrag0ndonate). All support is appreciated!**
+
+# v2.2.1 (Zygisk)
+
+**This version only supports Zygisk. See v2.1.3 for a Riru version.**
+
+- Fixed under-display fingerprint sensor on Realme devices (thanks @osm0sis, @byxiaorun, @Jowat97)
+- Clarified definition of "basic attestation" in readme
+- Add check to prevent installation on unsupported Android versions (7.x and older)
+
+# v2.1.3 (Riru)
+
+**This version only supports Riru. See v2.2.1 for a Riru version.**
+
+- Fixed under-display fingerprint sensor on Realme devices (thanks @osm0sis, @byxiaorun, @Jowat97)
+- Clarified definition of "basic attestation" in readme
+- Add check to prevent installation on unsupported Android versions (7.x and older)
+
+# v2.2.0 (Zygisk) 
+
+**This version only supports Zygisk. See v2.1.2 for a Riru version.**
+
+- **Ported module to Zygisk**
+- Fixed screen-off Voice Match in Google Assistant
+- Fixed poor microphone quality with Voice Match enabled on Pixel 5
+- Fixed At a Glance weather display on Android 12
+- Fixed At a Glance settings on Android 12
+
+# v2.1.2 (Riru) 
+
+**This version only supports Riru. See v2.2.0 for a Riru version.**
+
+- Fixed screen-off Voice Match in Google Assistant
+- Fixed poor microphone quality with Voice Match enabled on Pixel 5
+- Fixed At a Glance weather display on Android 12
+- Fixed At a Glance settings on Android 12
+
+# v2.1.1
+
+- Fixed under-display fingerprint on OnePlus devices (@osm0sis)
+
+# v2.1.0
+
+- **Fixed new SafetyNet CTS profile failures as of September 2, 2021**
+- Added MagiskHide features that will be removed in future versions of Magisk
+
+# v2.0.0
+
+- **Added support for heavy OEM skins (One UI, MIUI, etc.)**
+- Added support for Android 12 Beta 4 and future versions
+- Fixed broken Play Services features other than SafetyNet
+- Fixed rare system freezes caused by Play Services breakage
+- Android 12: Fixed face unlock on Pixel 4 series
+- Added support for Android 7.0 and 7.1
+- Rewritten as a Riru module
+
+# v1.2.0
+
+- Added support for Android 12 Beta 2
+- Fixed bootloop after major Android updates
+
+# v1.1.1
+
+- Removed security patch fixup to fix CTS profile mismatches on some devices
+
+# v1.1.0
+
+- Added support for Android 8.0, 8.1, 9, and 10
+- Increased chances of passing SafetyNet on older devices
+
+# v1.0.2
+
+- Rebuilt executables and libraries for generic ARMv8-A CPUs to maximize compatibility
+- Increased chances of passing SafetyNet on stock ROMs
+
+# v1.0.1
+
+- Rebuilt executables and libraries for generic ARMv8-A CPUs to maximize compatibility
+
+# v1.0.0
+
+- Initial release

--- a/magisk/module.prop
+++ b/magisk/module.prop
@@ -4,3 +4,4 @@ version=v2.2.1
 versionCode=20201
 author=kdrag0n
 description=A universal fix for SafetyNet on Android 8–12 devices with hardware attestation and unlocked bootloaders.
+updateJson=https://raw.githubusercontent.com/kdrag0n/safetynet-fix/master/update.json

--- a/update.json
+++ b/update.json
@@ -1,0 +1,6 @@
+{
+    "version": "v2.2.1",
+    "versionCode": 20201,
+    "zipUrl": "https://github.com/kdrag0n/safetynet-fix/releases/download/v2.2.1/safetynet-fix-v2.2.1.zip",
+    "changelog": "https://github.com/kdrag0n/safetynet-fix/releases"
+}

--- a/update.json
+++ b/update.json
@@ -2,5 +2,5 @@
     "version": "v2.2.1",
     "versionCode": 20201,
     "zipUrl": "https://github.com/kdrag0n/safetynet-fix/releases/download/v2.2.1/safetynet-fix-v2.2.1.zip",
-    "changelog": "https://github.com/kdrag0n/safetynet-fix/releases"
+    "changelog": "https://raw.githubusercontent.com/kdrag0n/safetynet-fix/master/CHANGELOG.md"
 }


### PR DESCRIPTION
This adds the update.json file used in Magisk v24 and above, as defined at https://topjohnwu.github.io/Magisk/guides.html#moduleprop. This is also discussed briefly in #136.

The json is populated for v2.2.1, so will have to be bumped alongside module.props whenever a new version is released.