### PR TITLE
Only remove gms if Denylist is enforced

### DIFF
--- a/magisk/post-fs-data.sh
+++ b/magisk/post-fs-data.sh
@@ -1,4 +1,6 @@
 #!/system/bin/sh
 
-# Remove Play Services from DenyList, otherwise the Zygisk module won't load
-magisk --denylist rm com.google.android.gms
+# Remove Play Services from the Magisk Denylist when set to enforcing.
+if magisk --denylist status; then
+	magisk --denylist rm com.google.android.gms
+fi


### PR DESCRIPTION
Originally Magisk required the Denylist to be enforced to access the Denylist.
When enforced, Magisk is unloaded while the processes on the Denylist are called.

Now you can access the Denylist when it is not enforced.
Since Magisk runs normally when not enforced, the Denylist is just a list.

No need to remove 'gms' from the Denylist when it is not enforced.