### PR TITLE
magisk: fix Oppo fingerprint reader issues

### DIFF
--- a/magisk/service.sh
+++ b/magisk/service.sh
@@ -37,6 +37,9 @@ fi
     # avoid breaking Realme fingerprint scanners
     resetprop ro.boot.flash.locked 1
 
+    # avoid breaking Oppo fingerprint scanners
+    resetprop ro.boot.vbmeta.device_state locked
+
     # avoid breaking OnePlus display modes/fingerprint scanners
     resetprop vendor.boot.verifiedbootstate green
 }&

--- a/magisk/system.prop
+++ b/magisk/system.prop
@@ -15,7 +15,6 @@ ro.is_ever_orange=0
 # SafetyNet
 ro.boot.verifiedbootstate=green
 ro.boot.veritymode=enforcing
-ro.boot.vbmeta.device_state=locked
 vendor.boot.vbmeta.device_state=locked
 
 # Other


### PR DESCRIPTION
- move ro.boot.vbmeta.device_state to late props since any earlier appears to break Oppo (ColorOS/OOS12+) fingerprint readers

Thanks @MlgmXyysd

Fixes #157