### PR TITLE
Set shipping level to 32 for devices >=33

### DIFF
--- a/magisk/service.sh
+++ b/magisk/service.sh
@@ -42,4 +42,9 @@ fi
 
     # avoid breaking OnePlus display modes/fingerprint scanners
     resetprop vendor.boot.verifiedbootstate green
+
+    # avoid breaking encryption, set shipping level to 32 for devices >=33 to allow for software attestation.
+    if [[ "$(getprop ro.product.first_api_level)" -ge 33 ]]; then
+        resetprop ro.product.first_api_level 32
+    fi
 }&


### PR DESCRIPTION
If ro.product.first_api_level is 33, its forced to use HW attestation even though the safteynet checker app shows BASIC
Setting it to 32 allows for software attestation and passing CTS

Reference tweet: https://twitter.com/anirudhgupta109/status/1581187443478274048