### PR TITLE
Added sys.oem_unlock_allowed prop reset

### DIFF
--- a/magisk/service.sh
+++ b/magisk/service.sh
@@ -42,4 +42,7 @@ fi
 
     # avoid breaking OnePlus display modes/fingerprint scanners
     resetprop vendor.boot.verifiedbootstate green
+    
+    # makes bank apps and Google Pay happy
+    resetprop sys.oem_unlock_allowed 0
 }&


### PR DESCRIPTION
Makes bank apps and Google Pay happy, since even if the prop is otherwise spotless, those apps still wouldn't work because this prop is set to 1.

Was the only thing that I had to do to get my bank app to allow biometric unlock, and Google Pay to let me add my payment cards