### PR TITLE
Minor reduction of confusion re Magisk v23/24

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Magisk module to work around Google's SafetyNet attestation.
 
 This module works around hardware attestation and recent updates to SafetyNet CTS profile checks. You must already be able to pass basic CTS profile attestation, which requires a valid combination of device and model names, build fingerprints, and security patch levels.
 
-If you still have trouble passing SafetyNet with this module, use [MagiskHide Props Config](https://github.com/Magisk-Modules-Repo/MagiskHidePropsConf) to spoof a certified device profile. This is a common issue on old devices, custom ROMs, and stock ROMs without GMS certification (e.g. Chinese ROMs).
+If you still have trouble passing SafetyNet with this module and have Magisk v23 or older, use [MagiskHide Props Config](https://github.com/Magisk-Modules-Repo/MagiskHidePropsConf) to spoof a certified device profile. This is a common issue on old devices, custom ROMs, and stock ROMs without GMS certification (e.g. Chinese ROMs).
 
 Android versions up to 13 Beta 3 are supported, including OEM skins such as Samsung One UI and MIUI.
 


### PR DESCRIPTION
MagiskHide Props Config does not support Magisk v24, so it may be worthwhile mentioning to the newer users.

[Related issue](https://github.com/Magisk-Modules-Repo/MagiskHidePropsConf/issues/142)