### PR TITLE
service: fix possible empty shipping level returns

### DIFF
--- a/magisk/service.sh
+++ b/magisk/service.sh
@@ -47,6 +47,13 @@ fi
     resetprop ro.boot.verifiedbootstate green
     resetprop ro.boot.veritymode enforcing
     resetprop vendor.boot.vbmeta.device_state locked
+	
+    # Fix empty returns for shipping level
+    if [[ "$(getprop ro.product.first_api_level)"]]; then
+        echo "No need"
+    else
+       resetprop -n ro.product.first_api_level $(getprop ro.build.version.sdk)
+    fi
 
     # Avoid breaking encryption, set shipping level to 32 for devices >=33 to allow for software attestation
     if [[ "$(getprop ro.product.first_api_level)" -ge 33 ]]; then


### PR DESCRIPTION
Some developers leave the shipping level blank, in these cases, we can try to create it again via the sdk level.