### PR TITLE
use the standard `ANDROID_HOME` variable to locate ndk

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ debug_mode=1
 if [[ "$build_mode" == "release" ]]; then
     debug_mode=0
 fi
-$HOME/code/android/sdk/ndk/21.4.7075529/ndk-build -j48 NDK_DEBUG=$debug_mode
+$ANDROID_HOME/ndk/21.4.7075529/ndk-build -j48 NDK_DEBUG=$debug_mode
 popd
 
 pushd java


### PR DESCRIPTION
ANDROID_HOME is a standard variable in the Android development world. Using it to locate the NDK avoids changing scripts on every machine.